### PR TITLE
Code refactoring and spacing

### DIFF
--- a/lua/confirm-quit/config.lua
+++ b/lua/confirm-quit/config.lua
@@ -11,10 +11,13 @@ function M.set(user_conf)
 		M.options = default_config
 		return default_config
 	end
+
 	if type(user_conf) ~= "table" then
 		error("Configuration error")
 	end
+
 	M.options = vim.tbl_deep_extend("force", default_config, user_conf or {})
+
 	return M.options
 end
 

--- a/lua/confirm-quit/init.lua
+++ b/lua/confirm-quit/init.lua
@@ -4,35 +4,44 @@ local config = require("confirm-quit.config")
 local function is_last_window()
 	local wins = vim.api.nvim_list_wins()
 	local count = 0
+
 	for _, v in ipairs(wins) do
 		local win = vim.api.nvim_win_get_config(v).relative
+
 		if win == "" then
 			count = count + 1
 		end
 	end
-	if count == 1 then
-		return true
-	end
-	return false
+
+	return count == 1
 end
 
 function M.confirm_quit()
-	if is_last_window() and vim.fn.tabpagenr("$") == 1 then
-		if vim.fn.confirm("Do you want to quit?", "&Yes\n&No", 2) ~= 1 then
-			return
-		end
+	local is_last_tab_page = vim.fn.tabpagenr("$") == 1
+
+	if not is_last_window() then
+		vim.cmd.quit()
+		return
 	end
-	vim.cmd.quit()
+	if not is_last_tab_page then
+		vim.cmd.quit()
+		return
+	end
+
+	if vim.fn.confirm("Do you want to quit?", "&Yes\n&No", 2, "Question") == 1 then
+		vim.cmd.quit()
+	end
 end
 
 local function setup_cmdline_quit()
-	if config.options.overwrite_q_command == true then
-		vim.cmd([[cnoreabbrev <expr> q (getcmdtype() ==# ":" && getcmdline() ==# "q") ? "ConfirmQuit" : "q" ]])
-		vim.api.nvim_create_user_command("ConfirmQuit", function()
-			require("confirm-quit").confirm_quit()
-		end, { force = true })
-		vim.cmd([[cnoreabbrev qq  quit]])
+	if config.options.overwrite_q_command then
+		vim.cmd([[ cnoreabbrev <expr> q (getcmdtype() == ":" && getcmdline() ==# "q") ? "ConfirmQuit" : "q" ]])
+		vim.cmd([[ cnoreabbrev qq quit ]])
 	end
+
+	vim.api.nvim_create_user_command("ConfirmQuit", function()
+		require("confirm-quit").confirm_quit()
+	end, { force = true })
 end
 
 function M.setup(user_conf)


### PR DESCRIPTION
Many blocks of code were mashed together which made the codebase harder to read, so I added some spaces.

It was also hard to decipher the conditional logic and I did a little de-nesting.

I also removed unnecessary parentheses where I thought it'd make the code look nicer; specifically, `require`s and `vim.cmd`s.