### PR TITLE
Added `:qa` counterpart and improved README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,23 @@ This plugin will give you a confirmation message when you close the last window.
 ## Installation
 
 ```lua
--- lazy
+-- Lazy
 { "yutkat/confirm-quit.nvim", event = "CmdlineEnter", config = true },
 
+-- Packer
+use {
+  "yutkat/confirm-quit.nvim",
+  event = "CmdlineEnter",
+  config = function() require "confirm-quit".setup() end,
+}
+```
+
+## Keymaps
+
+```lua
+-- :q
+vim.keymap.set("n", "<leader>q", require "confirm-quit".confirm_quit)
+
+-- :qa
+vim.keymap.set("n", "<leader>Q", function() require "confirm-quit".confirm_quit(true) end)
 ```

--- a/lua/confirm-quit/init.lua
+++ b/lua/confirm-quit/init.lua
@@ -16,8 +16,22 @@ local function is_last_window()
 	return count == 1
 end
 
-function M.confirm_quit()
+local function user_wants_to_quit()
+	return vim.fn.confirm("Do you want to quit?", "&Yes\n&No", 2, "Question") == 1
+end
+
+function M.confirm_quit(quit_all)
 	local is_last_tab_page = vim.fn.tabpagenr("$") == 1
+
+	-- Lua doesn't short circuit with conditional logic
+	-- so the following code can't be refactored further
+	if quit_all then
+		if user_wants_to_quit() then
+			vim.cmd.quitall()
+		end
+
+		return
+	end
 
 	if not is_last_window() then
 		vim.cmd.quit()
@@ -28,7 +42,7 @@ function M.confirm_quit()
 		return
 	end
 
-	if vim.fn.confirm("Do you want to quit?", "&Yes\n&No", 2, "Question") == 1 then
+	if user_wants_to_quit() then
 		vim.cmd.quit()
 	end
 end
@@ -41,6 +55,10 @@ local function setup_cmdline_quit()
 
 	vim.api.nvim_create_user_command("ConfirmQuit", function()
 		require("confirm-quit").confirm_quit()
+	end, { force = true })
+
+	vim.api.nvim_create_user_command("ConfirmQuitAll", function()
+		require("confirm-quit").confirm_quit(true)
 	end, { force = true })
 end
 


### PR DESCRIPTION
Added `quit_all` parameter to `confirm_quit`. If `false`/`nil`, function as usual, otherwise, act like `:qa` with confirmation.
Also, made some tweaks to README.