### PR TITLE
feat: extend custom quit message

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ use {
 ```lua
 {
   overwrite_q_command = true, -- Replaces :q and :qa with :ConfirmQuit and :ConfirmQuitAll
+  quit_message = 'Do you want to quit?', -- Message to show when quitting, can be a function returning a string
 }
 ```
 

--- a/lua/confirm-quit/init.lua
+++ b/lua/confirm-quit/init.lua
@@ -2,7 +2,7 @@ local M = {}
 
 local options = {
 	overwrite_q_command = true,
- 	quit_message = "Do you want to quit?",
+	quit_message = "Do you want to quit?",
 }
 
 local GENERIC_ERROR_MESSAGE = "ConfirmQuit: Error while quitting"
@@ -36,7 +36,10 @@ local function is_last_window()
 end
 
 local function prompt_user_to_quit()
-	return vim.fn.confirm(options.quit_message, "&Yes\n&No", 2, "Question") == 1
+	local quit_message = type(options.quit_message) == "function"
+                       and options.quit_message()
+                       or options.quit_message
+	return vim.fn.confirm(quit_message, "&Yes\n&No", 2, "Question") == 1
 end
 
 --- A wrapper for pcall that just prints an error in case of failure


### PR DESCRIPTION
Hi @yutkat,

I recently started using this plugin and found it super useful. This PR allows the custom message to be a function returning a string.

Having that function would allow you to customize the message depending on the current buffer, or to display a random message.

See this configuration as an example:

https://github.com/davidmh/dot-files/blob/d02db57a7d2b45aca46a1de22bc9df86b8829bbb/nvim/fnl/plugins/ui.fnl#L6-L26